### PR TITLE
[READY] - Fixed 1.18 usage and addded vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The overall cost to run this project varies greatly with usage and instance size
 | mc\_home\_folder | The location of the Minecraft server files on the instance | `string` | `"/home/minecraft"` | no |
 | mc\_forge\_server\_download\_link | The direct download link to MC forge for modding support. Defaults to version 1.16.5. | `string` | "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.16.5-36.1.0/forge-1.16.5-36.1.0-installer.jar"
 | mc\_server\_download\_link | The direct download link to download the server jar. Defaults to a link with 1.16.5. | `string` | `"https://launcher.mojang.com/v1/objects/35139deedbd5182953cf1caa23835da59ca3d7cd/server.jar"` | no |
+| override\_server\_activate\_cmd | Should the bootstrap use a different server command than java -Xms server_min_ram -Xmx server_max_ram -jar /home/minecraft/server.jar nogui? If left blank, uses said default command | `string` | "" | no
 | project\_name | The name of the project. Not to be confused with the project name in GCP; this is moreso a terraform project name. | `string` | `"mc-server-bootstrap"` | no |
 | region | The region used to place these resources. Defaults to us-west1 | `string` | `"us-west2"` | no |
 | server\_image | The boot image used on the server. Defaults to `ubuntu-1804-bionic-v20191211` | `string` | `"ubuntu-1804-bionic-v20191211"` | no |
@@ -134,6 +135,7 @@ While most of the configuration has verbose descriptions, there are some options
 |`mc_forge_server_download_link` | There are a multitude of mod loaders for MC, which would make this project rise in complexity. For simplicity sake, the project supports [MC Forge](https://files.minecraftforge.net/) as the mod loader of choice. Any other one is not supported. |
 | `server_property_template` | This could change consistenty in the server, making it tricky to keep track of in this code. As such, any new changes made after the initial deployment of the server will __NOT__ be reflected in code. To use a new config if one changed it outside of the server, one must manually go onto the instance and edit the config to match what is down in code. |
 | `existing_subnetwork_name` | This allows for multiple instances of this module to be deployed in the same network, for easier management. To properly use this, make sure one module of this stack is deployed, with the other module calls referencing the `created_subnetwork` output of the first module. |
+| `override_server_activate_cmd` | There is a slight change in the logic for bootstrapping Forge in 1.18, specifically with the nonexistance of the server jar to run after installing Forge. Instead, they change running the command to just a bash script, `run.sh`. This needs to be reflected in the command, hence this variable. |
 
 ## General Server Management
 

--- a/data.tf
+++ b/data.tf
@@ -9,7 +9,8 @@ locals {
   mount_location     = "/dev/sdb"
   jar_name           = "server.jar"
   screen_ses         = "mc_server"
-  screen_cmd         = "java -Xms${var.server_min_ram} -Xmx${var.server_max_ram} -jar ${var.mc_home_folder}/${local.jar_name} nogui"
+
+  screen_cmd = var.override_server_activate_cmd == "" ? "java -Xms${var.server_min_ram} -Xmx${var.server_max_ram} -jar ${var.mc_home_folder}/${local.jar_name} nogui" : var.override_server_activate_cmd
 
   common_labels = {
     project   = var.project_name
@@ -41,6 +42,8 @@ data "template_file" "bootstrap" {
     backup_cron             = var.backup_cron
     instance_name           = local.instance_name
     zone_name               = local.zone_name
+    min_ram                 = var.server_min_ram
+    max_ram                 = var.server_max_ram
     backup_key              = "backup-conf"
     restore_key             = "restore-conf"
     restart_key             = "restart-conf"

--- a/templates/bootstrap.tpl
+++ b/templates/bootstrap.tpl
@@ -23,8 +23,9 @@ prepare_ssd() {
 }
 
 install_pre_req() {
+    add-apt-repository -y ppa:openjdk-r/ppa 
     apt-get update
-    apt-get install -y default-jre-headless zip unzip screen less
+    apt-get install -y default-jre-headless openjdk-17-jdk zip unzip screen less
     
     if [ $(command -v gsutil &> /dev/null)  ]; then
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -37,7 +38,7 @@ install_pre_req() {
 
 setup_mc_server() {
     cd ${mc_home_folder}
-    if [ ! -f "${mc_home_folder}/${jar_name}" ]; then
+    if [ ! -f "${mc_home_folder}/eula.txt" ]; then
         if [ "${is_modded}" == "true" ]; then             
             installer_name=$(basename ${mc_server_download_link})
             result_name=$${installer_name/-installer/}
@@ -46,8 +47,13 @@ setup_mc_server() {
             java -jar ${mc_home_folder}/$${installer_name} --installServer
             
             rm -f ${mc_home_folder}/$${installer_name}
-            mv -f ${mc_home_folder}/$${result_name} ${mc_home_folder}/${jar_name}
-
+            if [ ! -f "${mc_home_folder}/user_jvm_args.txt" ]; then
+                mv -f ${mc_home_folder}/$${result_name} ${mc_home_folder}/${jar_name}
+            else
+                echo "" >> ${mc_home_folder}/user_jvm_args.txt
+                echo "-Xms${min_ram}" >> ${mc_home_folder}/user_jvm_args.txt
+                echo "-Xmx${max_ram}" >> ${mc_home_folder}/user_jvm_args.txt
+            fi
         else
             wget -O ${mc_home_folder}/${jar_name} ${mc_server_download_link}
         fi

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,9 @@ variable "is_modded" {
   type        = bool
   default     = false
 }
+
+variable "override_server_activate_cmd" {
+  description = "Should the bootstrap use a different server command than java -Xms server_min_ram -Xmx server_max_ram -jar /home/minecraft/server.jar nogui? If left blank, uses said default command"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
There were some bugs when using this module upon trying to spin a 1.18 modded MC server with forge. This PR fixes this by
- Adding in `openjdk-17-jdk` to make sure wwe get the latest version of java installed (Jave SE 17)
- Changing logic in workflow to account for new MC version
- Added new variable which overrided the default server spinup command if used.